### PR TITLE
Improved kernel loader's end

### DIFF
--- a/applications/idle/src/idle.cpp
+++ b/applications/idle/src/idle.cpp
@@ -27,7 +27,8 @@
 int main() {
 	signal(SIGINT, SIG_IGN);
 
-	asm("cli");
+	again:
 	asm("hlt");
+	goto again;
 }
 

--- a/applications/idle/src/idle.cpp
+++ b/applications/idle/src/idle.cpp
@@ -27,8 +27,7 @@
 int main() {
 	signal(SIGINT, SIG_IGN);
 
-	again:
+	asm("cli");
 	asm("hlt");
-	goto again;
 }
 


### PR DESCRIPTION
CLI and HLT is put in kernel loader rather than HLT in loop in bootloader.